### PR TITLE
feat: publicar el contrato de la Api con OpenAPI y Scalar

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -4,14 +4,23 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
+    <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)</OpenApiDocumentsDirectory>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.10">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.17" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
   </ItemGroup>
 

--- a/Api/Api.json
+++ b/Api/Api.json
@@ -1,0 +1,561 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Bitákora — Incapacidades",
+    "description": "Liquidación de incapacidades laborales según la normativa colombiana.",
+    "version": "v1"
+  },
+  "paths": {
+    "/Empleado": {
+      "get": {
+        "tags": [
+          "Api"
+        ],
+        "summary": "Lista los empleados con su salario ya desagregado",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Empleado"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Incapacidad": {
+      "post": {
+        "tags": [
+          "Api"
+        ],
+        "summary": "Liquida una incapacidad y la guarda con sus reconocimientos económicos",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SolicitudIncapacidad"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/IncapacidadConsulta/{idEmpleado}": {
+      "get": {
+        "tags": [
+          "Api"
+        ],
+        "summary": "Incapacidades de un empleado, con el total a pagar de cada una",
+        "parameters": [
+          {
+            "name": "idEmpleado",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DetalleIncapacidad"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/CalcularFechas": {
+      "get": {
+        "tags": [
+          "Api"
+        ],
+        "summary": "Fecha en que termina un período que empieza en la fecha dada",
+        "parameters": [
+          {
+            "name": "anio",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "mes",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "dia",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cantidadDias",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ReconocimientoEconomico/{idEmpleado}": {
+      "get": {
+        "tags": [
+          "Api"
+        ],
+        "summary": "Reconocimientos económicos de un empleado, con su responsable de pago",
+        "parameters": [
+          {
+            "name": "idEmpleado",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DetalleReconocimientoEconomico"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DetalleIncapacidad": {
+        "required": [
+          "id",
+          "tipo",
+          "fechaInicial",
+          "fechaFinal",
+          "cantidadDias",
+          "totalAPagar"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "tipo": {
+            "type": "string"
+          },
+          "fechaInicial": {
+            "type": "string"
+          },
+          "fechaFinal": {
+            "type": "string"
+          },
+          "cantidadDias": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "totalAPagar": {
+            "$ref": "#/components/schemas/Dinero"
+          }
+        }
+      },
+      "DetalleReconocimientoEconomico": {
+        "required": [
+          "idIncapacidad",
+          "fechaInicial",
+          "fechaFinal",
+          "valorAPagar",
+          "responsablePago"
+        ],
+        "type": "object",
+        "properties": {
+          "idIncapacidad": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "fechaInicial": {
+            "type": "string"
+          },
+          "fechaFinal": {
+            "type": "string"
+          },
+          "valorAPagar": {
+            "$ref": "#/components/schemas/Dinero"
+          },
+          "responsablePago": {
+            "type": "string"
+          }
+        }
+      },
+      "Dinero": {
+        "required": [
+          "cantidad",
+          "moneda"
+        ],
+        "type": "object",
+        "properties": {
+          "cantidad": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "moneda": {
+            "type": "string"
+          }
+        }
+      },
+      "Empleado": {
+        "required": [
+          "id",
+          "nombres",
+          "apellidos",
+          "salario",
+          "tipoSalario"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "nombres": {
+            "type": "string"
+          },
+          "apellidos": {
+            "type": "string"
+          },
+          "salario": {
+            "$ref": "#/components/schemas/Dinero"
+          },
+          "salarioDiario": {
+            "$ref": "#/components/schemas/Dinero"
+          },
+          "salarioDiarioPorPorcentajeSalario": {
+            "$ref": "#/components/schemas/Dinero"
+          },
+          "salarioDiarioPorPorcentajeCompensacion": {
+            "$ref": "#/components/schemas/Dinero"
+          },
+          "tipoSalario": {
+            "$ref": "#/components/schemas/TipoSalario"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "SolicitudIncapacidad": {
+        "required": [
+          "idEmpleado",
+          "tipoIncapacidad",
+          "anio",
+          "mes",
+          "dia",
+          "cantidadDias",
+          "observaciones"
+        ],
+        "type": "object",
+        "properties": {
+          "idEmpleado": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "tipoIncapacidad": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "anio": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "mes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "dia": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "cantidadDias": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "observaciones": {
+            "type": "string"
+          },
+          "fechaInicial": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tipoDeIncapacidad": {
+            "$ref": "#/components/schemas/TipoIncapacidad"
+          }
+        }
+      },
+      "Tipo": {
+        "type": "integer"
+      },
+      "TipoIncapacidad": {
+        "type": "integer"
+      },
+      "TipoSalario": {
+        "type": "object",
+        "properties": {
+          "tipo": {
+            "$ref": "#/components/schemas/Tipo"
+          },
+          "porcentajeSalario": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "porcentajeCompensacion": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Api"
+    }
+  ]
+}

--- a/Api/Empleados/EmpleadosEnHttp.cs
+++ b/Api/Empleados/EmpleadosEnHttp.cs
@@ -7,6 +7,9 @@ public static class EmpleadosEnHttp
     public static void MapearEmpleados(this IEndpointRouteBuilder rutas)
     {
         rutas.MapGet("/Empleado", (IConsultarEmpleados consultarEmpleados) =>
-            consultarEmpleados.ObtenerEmpleados());
+                consultarEmpleados.ObtenerEmpleados())
+            .WithSummary("Lista los empleados con su salario ya desagregado")
+            .Produces<List<Empleado>>()
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
     }
 }

--- a/Api/Incapacidades/IncapacidadesEnHttp.cs
+++ b/Api/Incapacidades/IncapacidadesEnHttp.cs
@@ -7,15 +7,26 @@ public static class IncapacidadesEnHttp
     public static void MapearIncapacidades(this IEndpointRouteBuilder rutas)
     {
         rutas.MapPost("/Incapacidad",
-            (SolicitudIncapacidad solicitudIncapacidad, ICreadorIncapacidad creadorIncapacidad) =>
-                creadorIncapacidad.Crear(solicitudIncapacidad));
+                (SolicitudIncapacidad solicitudIncapacidad, ICreadorIncapacidad creadorIncapacidad) =>
+                    creadorIncapacidad.Crear(solicitudIncapacidad))
+            .WithSummary("Liquida una incapacidad y la guarda con sus reconocimientos económicos")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
 
         rutas.MapGet("/IncapacidadConsulta/{idEmpleado:int}",
-            (int idEmpleado, IIncapacidadServicio incapacidadServicio) =>
-                incapacidadServicio.ObtenerIncapacidadesDetalle(idEmpleado));
+                (int idEmpleado, IIncapacidadServicio incapacidadServicio) =>
+                    incapacidadServicio.ObtenerIncapacidadesDetalle(idEmpleado))
+            .WithSummary("Incapacidades de un empleado, con el total a pagar de cada una")
+            .Produces<List<DetalleIncapacidad>>()
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
 
         rutas.MapGet("/CalcularFechas",
-            (int anio, int mes, int dia, int cantidadDias, ICalcularFechas calcularFechas) =>
-                calcularFechas.CalcularSiguienteFecha(new DateTime(anio, mes, dia), cantidadDias));
+                (int anio, int mes, int dia, int cantidadDias, ICalcularFechas calcularFechas) =>
+                    calcularFechas.CalcularSiguienteFecha(new DateTime(anio, mes, dia), cantidadDias))
+            .WithSummary("Fecha en que termina un período que empieza en la fecha dada")
+            .Produces<DateTime>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
     }
 }

--- a/Api/Liquidacion/LiquidacionEnHttp.cs
+++ b/Api/Liquidacion/LiquidacionEnHttp.cs
@@ -1,4 +1,5 @@
 using Bitakora.Incapacidades;
+using Bitakora.Liquidacion;
 
 namespace Api.Liquidacion;
 
@@ -7,7 +8,10 @@ public static class LiquidacionEnHttp
     public static void MapearLiquidacion(this IEndpointRouteBuilder rutas)
     {
         rutas.MapGet("/ReconocimientoEconomico/{idEmpleado:int}",
-            (int idEmpleado, IIncapacidadServicio incapacidadServicio) =>
-                incapacidadServicio.ObtenerReconocimientosEconomicosDetalle(idEmpleado));
+                (int idEmpleado, IIncapacidadServicio incapacidadServicio) =>
+                    incapacidadServicio.ObtenerReconocimientosEconomicosDetalle(idEmpleado))
+            .WithSummary("Reconocimientos económicos de un empleado, con su responsable de pago")
+            .Produces<List<DetalleReconocimientoEconomico>>()
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
     }
 }

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -1,6 +1,7 @@
 using Api.Empleados;
 using Api.Incapacidades;
 using Api.Liquidacion;
+using Scalar.AspNetCore;
 
 namespace Api;
 
@@ -28,6 +29,9 @@ public class Program
         app.MapearEmpleados();
         app.MapearIncapacidades();
         app.MapearLiquidacion();
+
+        app.MapOpenApi();
+        app.MapScalarApiReference();
 
         app.Run();
     }

--- a/Api/ServiciosDeBitakora.cs
+++ b/Api/ServiciosDeBitakora.cs
@@ -4,6 +4,7 @@ using Bitakora.Liquidacion;
 using Bitakora.Persistencia;
 using Bitakora.Salarios;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi;
 
 namespace Api;
 
@@ -22,6 +23,19 @@ public static class ServiciosDeBitakora
 
         servicios.AddProblemDetails();
         servicios.AddExceptionHandler<ExcepcionesDelDominioComoHttp>();
+
+        servicios.AddOpenApi(opciones => opciones.AddDocumentTransformer(
+            (documento, _, _) =>
+            {
+                documento.Info = new OpenApiInfo
+                {
+                    Title = "Bitákora — Incapacidades",
+                    Version = "v1",
+                    Description = "Liquidación de incapacidades laborales según la normativa colombiana."
+                };
+
+                return Task.CompletedTask;
+            }));
 
         servicios.ConfigureHttpJsonOptions(opciones => opciones.SerializerOptions.WriteIndented = true);
 

--- a/README.md
+++ b/README.md
@@ -9,19 +9,80 @@ económicos.
 
 - .NET 10 SDK
 
-## Ejecutar
+## Correr y verificar en local
+
+### 1. Antes de arrancar: la base tiene que existir
+
+La base es SQLite y vive en `Api/Incapacidades.db`. **No está versionada** —el `.gitignore` excluye
+`*.db`— pero trae los empleados sembrados y **nada la recrea al arrancar**: sin ese archivo todos
+los endpoints responden 500.
+
+```bash
+ls Api/Incapacidades.db || git show b765f90:Api/Incapacidades.db > Api/Incapacidades.db
+```
+
+Las migraciones están en `Api/Migrations/`; para recrearla desde cero, `dotnet ef database update`
+desde `Api`.
+
+### 2. Levantar
 
 ```bash
 cd Api
 dotnet run
 ```
 
-Luego abrir https://localhost:5001/index.html (también responde en http://localhost:5000).
+Responde en `https://localhost:5001` y en `http://localhost:5000`. El pipeline tiene
+`UseHttpsRedirection`, así que **el puerto 5000 redirige con 307 al 5001**: en el navegador es
+transparente, pero con `curl` hay que usar `https` o agregar `-L`.
 
-La base es SQLite y vive en `Api/Incapacidades.db`. **No está versionada** —el `.gitignore` excluye
-`*.db`— pero trae los empleados sembrados y **nada la recrea al arrancar**: sin ese archivo todos los
-endpoints responden 500. Las migraciones están en `Api/Migrations/`; para recrearla, `dotnet ef
-database update` desde `Api`.
+La primera vez conviene confiar el certificado de desarrollo, o el navegador va a advertir:
+
+```bash
+dotnet dev-certs https --trust
+```
+
+| Abrir | Para |
+| --- | --- |
+| https://localhost:5001/index.html | El front: cargar una incapacidad y ver su liquidación |
+| https://localhost:5001/scalar/v1 | Explorar y **probar** los endpoints desde el navegador |
+| https://localhost:5001/openapi/v1.json | El documento crudo |
+
+### 3. Verificar de punta a punta
+
+El camino feliz, que es lo que conviene mirar cuando se toca algo. El `-k` es porque el certificado
+de desarrollo no está confiado; si corriste `dev-certs --trust`, sobra:
+
+```bash
+API=https://localhost:5001
+
+curl -sk $API/Empleado                      # 200, Alan y Richard
+curl -sk "$API/CalcularFechas/?anio=2020&mes=6&dia=3&cantidadDias=4"   # "2020-06-06T00:00:00"
+
+SOLICITUD='{"idEmpleado":2,"tipoIncapacidad":1,"anio":2020,"mes":6,"dia":3,"cantidadDias":4,"observaciones":"x"}'
+curl -sk -X POST $API/Incapacidad -H 'Content-Type: application/json' -d "$SOLICITUD"
+
+curl -sk $API/IncapacidadConsulta/2         # la incapacidad con su totalAPagar
+curl -sk $API/ReconocimientoEconomico/2     # los tramos: EMPRESA los días 1-2, EPS del 3 en adelante
+```
+
+Y que los errores sigan saliendo con su código y su mensaje:
+
+```bash
+post() { curl -sk -o /dev/null -w "%{http_code}\n" -X POST $API/Incapacidad \
+           -H 'Content-Type: application/json' -d "$1"; }
+
+post '{"idEmpleado":2,"tipoIncapacidad":1,"anio":2020,"mes":6,"dia":3,"cantidadDias":0,"observaciones":"x"}'
+# 400 — "Una incapacidad dura al menos un día, y se pidieron 0."
+
+post '{"idEmpleado":999,"tipoIncapacidad":1,"anio":2020,"mes":6,"dia":3,"cantidadDias":4,"observaciones":"x"}'
+# 404 — "No existe un empleado con el id 999."
+
+post '{"idEmpleado":2,"tipoIncapacidad":1,"anio":2020,"mes":6,"dia":3,"cantidadDias":600,"observaciones":"x"}'
+# 400 — se pasa del día 540, no se liquida a medias
+```
+
+Desde `/scalar/v1` se puede hacer lo mismo sin salir del navegador, con el botón de probar de cada
+endpoint.
 
 ## Tests
 
@@ -29,9 +90,15 @@ database update` desde `Api`.
 dotnet test
 ```
 
-Son 85 tests con xUnit y Shouldly. Cubren la creación de incapacidades extremo a extremo contra una
-SQLite en memoria —para salario ordinario y para salario integral—, los cálculos de `ResponsablePago`
-y `Dinero`, la validación de la solicitud en el borde y los servicios de datos.
+Son **117 tests** con xUnit y Shouldly, en tres niveles:
+
+- **Dominio** — `Dinero`, `ResponsablePago`, `Incapacidad`, la validación de `SolicitudIncapacidad`.
+- **Servicios** — contra una SQLite en memoria, no contra la base de disco.
+- **Api** — los 5 endpoints por HTTP real con `WebApplicationFactory`, el mapeo excepción→HTTP, y el
+  documento OpenAPI contra las rutas que la Api expone de verdad.
+
+Los de Api son los que atrapan una ruta rota o un contrato cambiado: renombrar `/Empleado` hace caer
+tres.
 
 ## Endpoints
 
@@ -42,6 +109,23 @@ y `Dinero`, la validación de la solicitud en el borde y los servicios de datos.
 | `GET` | `/IncapacidadConsulta/{idEmpleado}` | Incapacidades de un empleado, con su total a pagar |
 | `GET` | `/ReconocimientoEconomico/{idEmpleado}` | Reconocimientos económicos de un empleado |
 | `GET` | `/CalcularFechas?anio=&mes=&dia=&cantidadDias=` | Fecha final de un período |
+| `GET` | `/openapi/v1.json` | El documento OpenAPI 3.1 de la Api |
+| `GET` | `/scalar/v1` | UI para explorar y probar la Api |
+
+## OpenAPI
+
+`Microsoft.AspNetCore.OpenApi` genera el documento a partir de los endpoints reales, así que el
+contrato se deriva del código en vez de describirse en prosa. **Scalar** lo muestra en `/scalar/v1`
+y sirve su propio bundle desde la app: no depende de ninguna CDN, igual que el front de `wwwroot`.
+
+El documento además se emite **en cada compilación** a `Api/Api.json`, que está versionado. Un
+cambio de contrato —una ruta, un campo, un status code— aparece como diff en la PR en vez de pasar
+desapercibido. La copia versionada no lleva la sección `servers`, que solo existe en tiempo de
+ejecución; eso la hace independiente del host.
+
+Los códigos de error se declaran endpoint por endpoint, no con un transformer uniforme: **solo
+`POST /Incapacidad` documenta un 404**, porque es el único que resuelve un empleado. Hay un test
+que verifica que los otros cuatro *no* lo declaren.
 
 ## Estructura
 

--- a/Test/Api/OpenApiTest.cs
+++ b/Test/Api/OpenApiTest.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using System.Text.Json;
+using Shouldly;
+using Xunit;
+
+namespace Test.Api;
+
+public class OpenApiTest : IClassFixture<ApiDePrueba>
+{
+    private readonly HttpClient _cliente;
+
+    public OpenApiTest(ApiDePrueba api)
+    {
+        _cliente = api.CreateClient();
+    }
+
+    private async Task<JsonElement> Documento()
+    {
+        HttpResponseMessage respuesta = await _cliente.GetAsync("/openapi/v1.json");
+
+        respuesta.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        return JsonDocument.Parse(await respuesta.Content.ReadAsStringAsync()).RootElement;
+    }
+
+    [Fact]
+    public async Task Debe_Servir_UnDocumentoOpenApi31()
+    {
+        JsonElement documento = await Documento();
+
+        documento.GetProperty("openapi").GetString()!.ShouldStartWith("3.1");
+        documento.GetProperty("info").GetProperty("title").GetString().ShouldBe("Bitákora — Incapacidades");
+    }
+
+    [Theory]
+    [InlineData("/Empleado", "get")]
+    [InlineData("/Incapacidad", "post")]
+    [InlineData("/IncapacidadConsulta/{idEmpleado}", "get")]
+    [InlineData("/CalcularFechas", "get")]
+    [InlineData("/ReconocimientoEconomico/{idEmpleado}", "get")]
+    public async Task Debe_Documentar_CadaRutaQueLaApiExpone(string ruta, string verbo)
+    {
+        JsonElement paths = (await Documento()).GetProperty("paths");
+
+        paths.TryGetProperty(ruta, out JsonElement path).ShouldBeTrue($"falta la ruta {ruta}");
+        path.TryGetProperty(verbo, out _).ShouldBeTrue($"falta el verbo {verbo} en {ruta}");
+    }
+
+    [Fact]
+    public async Task Debe_Documentar_LosTresErroresDeCrearIncapacidad()
+    {
+        JsonElement respuestas = (await Documento())
+            .GetProperty("paths").GetProperty("/Incapacidad").GetProperty("post").GetProperty("responses");
+
+        respuestas.TryGetProperty("400", out _).ShouldBeTrue();
+        respuestas.TryGetProperty("404", out _).ShouldBeTrue();
+        respuestas.TryGetProperty("500", out _).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("/Empleado", "get")]
+    [InlineData("/IncapacidadConsulta/{idEmpleado}", "get")]
+    [InlineData("/CalcularFechas", "get")]
+    [InlineData("/ReconocimientoEconomico/{idEmpleado}", "get")]
+    public async Task Debe_NoDocumentar404_Cuando_ElEndpointNoResuelveUnEmpleado(string ruta, string verbo)
+    {
+        JsonElement respuestas = (await Documento())
+            .GetProperty("paths").GetProperty(ruta).GetProperty(verbo).GetProperty("responses");
+
+        respuestas.TryGetProperty("404", out _).ShouldBeFalse($"{ruta} declara un 404 que nunca devuelve");
+    }
+
+    [Fact]
+    public async Task Debe_Describir_ElEmpleadoComoLoConsumeElFront()
+    {
+        JsonElement empleado = (await Documento())
+            .GetProperty("components").GetProperty("schemas").GetProperty("Empleado").GetProperty("properties");
+
+        empleado.TryGetProperty("nombres", out _).ShouldBeTrue();
+        empleado.TryGetProperty("salario", out _).ShouldBeTrue();
+        empleado.TryGetProperty("salarioDiario", out _).ShouldBeTrue();
+        empleado.GetProperty("tipoSalario").GetProperty("$ref").GetString().ShouldEndWith("/TipoSalario");
+    }
+
+    [Fact]
+    public async Task Debe_Describir_ElDineroConCantidadYMoneda()
+    {
+        JsonElement dinero = (await Documento())
+            .GetProperty("components").GetProperty("schemas").GetProperty("Dinero").GetProperty("properties");
+
+        dinero.TryGetProperty("cantidad", out _).ShouldBeTrue();
+        dinero.TryGetProperty("moneda", out _).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
La Api tenía un contrato de errores uniforme —SolicitudInvalida a 400, NoEncontrado a 404, el resto 500 sin filtrar el mensaje— que no estaba publicado en ningún lado: se descubría leyendo el código o probando con curl, y el README lo describía en prosa, que es justo lo que se desactualiza.

Microsoft.AspNetCore.OpenApi genera el documento a partir de los endpoints reales, en OpenAPI 3.1. Scalar lo muestra en /scalar/v1 sirviendo su propio bundle desde la app, sin depender de ninguna CDN. El documento además se emite en cada build a Api/Api.json, versionado, así un cambio de contrato aparece como diff en la PR en vez de pasar desapercibido; esa copia no lleva la sección servers, que solo existe en runtime, y por eso es independiente del host.

Los códigos de error se declaran endpoint por endpoint y no con un transformer uniforme, porque los cinco no comparten el mismo contrato: solo POST /Incapacidad puede dar 404, ya que es el único que resuelve un empleado. Documentar un 404 en los otros cuatro sería peor que no documentar nada, y hay un test que verifica que no lo declaren.

Las descripciones van como metadata fluida con WithSummary y no como comentarios XML, que es la vía que ofrece .NET 10 pero choca con la regla de no llevar comentarios en el código. WithSummary no es un comentario: es un dato que la Api sirve a sus clientes.

Microsoft.AspNetCore.OpenApi 10.0.10 arrastra Microsoft.OpenApi 2.0.0, que tiene una vulnerabilidad de gravedad alta (GHSA-v5pm-xwqc-g5wc, afecta todo <= 2.7.4) y metía 8 warnings en un build que estaba en cero. Queda fijada en 2.7.5, la primera parcheada de la misma línea mayor.

Tests: 104 -> 117. Los nuevos atan el documento a las rutas que la Api expone de
verdad: renombrar /Empleado hace caer tres.

El README documenta la ruta completa para correr y verificar en local, incluida la redirección 307 de UseHttpsRedirection, que obliga a usar https o -L al probar con curl.